### PR TITLE
Slack Incoming Webhooks instructions / interface has changed

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,8 +8,6 @@ module.exports = {
       domain: 'your.webhook.server.com',
       hookPath: '/irc-echo'
     },
-    echoChannel: '#irc-echo',
-    botName: 'IRCBot',
   },
   irc: {
     server: 'your.irc.net',

--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   slack: {
-    host: 'my.slack.com',
+    // URL sans 'https://hooks.slack.com/services/' prefix:
     incomingWebhookToken: 'your incoming webhook token',
     outgoingWebhookToken: 'your outgoing webhook token',
     outgoingWebhookServer: {

--- a/lib/main.js
+++ b/lib/main.js
@@ -24,26 +24,29 @@ var client = new irc.Client(config.irc.server, config.irc.nick, {
 
 slack.setClient(client);
 
+/*
+ * Forward and log messages to Slack
+ */
+
+function toSlack(to, text) {
+  var slacked = "[" + to + "] " + text;
+  console.log(slacked);
+  slack.sendEcho(slacked);
+}
 
 /*
  * Set up the IRC listeners
  */
 
 client.addListener('message', function(from, to, message) {
-  var room = to;
-  console.log(from + ' => ' + room + ': ' + message);
-
   // propagate the message to slack, even if it was a command
-  message = mapping.ircToSlack(message);
+  toSlack(to, "<" + mapping.ircToSlack(from) + "> " + mapping.ircToSlack(message));
 
-  var echoMessage = "[" + room + "] " + from + ": " + message;
-  slack.sendEcho(echoMessage);
-
-  // handle any commands
+  // handle any commands; pass along the unadulterated message
   var botResponse = ircCommands.handleCommand(from, to, message);
   if (botResponse) {
     client.say(config.irc.channel, botResponse);
-    slack.sendEcho("[" + room + "] " + config.irc.nick + ": " + botResponse);
+    toSlack(config.irc.channel, client.nick + ": " + botResponse);
   }
 });
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,9 +29,9 @@ slack.setClient(client);
  */
 
 function toSlack(to, text) {
-  var slacked = "[" + to + "] " + text;
-  console.log(slacked);
-  slack.sendEcho(slacked);
+  if (to == client.nick) text = "[private] " + text;
+  console.log(text);
+  slack.sendEcho(text);
 }
 
 /*

--- a/lib/main.js
+++ b/lib/main.js
@@ -54,6 +54,11 @@ client.addListener('action', function(from, to, text) {
   toSlack(to, "∙ _" + mapping.ircToSlack(from) + "_ " + mapping.ircToSlack(text));
 });
 
+client.addListener('topic', function(channel, topic, nick, message) {
+  if (message.command == "TOPIC") // don't forward topic on JOIN
+    toSlack(channel, "∙ _" + mapping.ircToSlack(nick) + "_ set the topic to: " + topic);
+});
+
 client.addListener('error', function(message) {
   console.log("ERROR: " + message);
 });

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,13 +34,18 @@ function toSlack(to, text) {
   slack.sendEcho(text);
 }
 
+// Intersperse Slack nick with WORD JOINER to avoid self-notification.
+function silently(nick) {
+  return mapping.ircToSlack(nick).split('').join('\u2060');
+}
+
 /*
  * Set up the IRC listeners
  */
 
 client.addListener('message', function(from, to, message) {
   // propagate the message to slack, even if it was a command
-  toSlack(to, "<" + mapping.ircToSlack(from) + "> " + mapping.ircToSlack(message));
+  toSlack(to, "<" + silently(from) + "> " + mapping.ircToSlack(message));
 
   // handle any commands; pass along the unadulterated message
   var botResponse = ircCommands.handleCommand(from, to, message);
@@ -51,12 +56,12 @@ client.addListener('message', function(from, to, message) {
 });
 
 client.addListener('action', function(from, to, text) {
-  toSlack(to, "∙ _" + mapping.ircToSlack(from) + "_ " + mapping.ircToSlack(text));
+  toSlack(to, "∙ _" + silently(from) + "_ " + mapping.ircToSlack(text));
 });
 
 client.addListener('topic', function(channel, topic, nick, message) {
   if (message.command == "TOPIC") // don't forward topic on JOIN
-    toSlack(channel, "∙ _" + mapping.ircToSlack(nick) + "_ set the topic to: " + topic);
+    toSlack(channel, "∙ _" + silently(nick) + "_ set the topic to: " + topic);
 });
 
 client.addListener('error', function(message) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,6 +50,10 @@ client.addListener('message', function(from, to, message) {
   }
 });
 
+client.addListener('action', function(from, to, text) {
+  toSlack(to, "∙ _" + mapping.ircToSlack(from) + "_ " + mapping.ircToSlack(text));
+});
+
 client.addListener('error', function(message) {
   console.log("ERROR: " + message);
 });

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -16,8 +16,8 @@ module.exports = {
   ircToSlack: function(originalMessage) {
     var modifiedMessage = originalMessage;
     _.each(userMap, function(val, key, list) {
-      var re = new RegExp("@?" + key, 'gi');
-      modifiedMessage = modifiedMessage.replace(re, "<@" + val + ">");
+      var re = new RegExp("\\b" + key + "\\b", 'gi');
+      modifiedMessage = modifiedMessage.replace(re, val);
     });
     return modifiedMessage;
   },

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -8,9 +8,9 @@ var mapping = require('./mapping');
 var ircClient;
 
 var slackPostOptions = {
-  hostname: config.slack.host,
+  hostname: 'hooks.slack.com',
   port: 443,
-  path: '/services/hooks/incoming-webhook?token=' + config.slack.incomingWebhookToken,
+  path: '/services/' + config.slack.incomingWebhookToken,
   method: 'POST'
 };
 

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -16,9 +16,7 @@ var slackPostOptions = {
 
 var sendToSlack = function(content) {
   var postContent = {
-    channel: config.slack.echoChannel,
-    username: config.slack.botName,
-    text: content 
+    text: content
   };
   var postBody = JSON.stringify(postContent);
 


### PR DESCRIPTION
Now all incoming requests go to `hooks.slack.com`, and the hook setup instructions doesn't refer to a ‘token’ any more.

I removed the 'channel' and 'username' options because this script cannot mirror to than one Slack channel at a time—nor does the channel / bot username ever change—and in any case can be configured via the defaults on the Slack hook configuration interface when setting one up.

Also, if a mapped nick speaks on IRC, the 'from' variable wasn't being mapped to the corresponding Slack nick.

Also, I improved the nick mapping by only matching on word boundaries.

Also, I took the liberty of adding support for '/me derps.'

Also, I decided to replace the `[#irc-channel]` tag from the text sent to Slack, since we do not monitor more than one channel per instance. Instead, we tags private messages to the bot as such.

Feel free to take any or all of the above. Or let me know which changes you're not sure about and I'll remove them from this PR.
